### PR TITLE
feat(label): add helper text for "I do not wish" options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - added helper text under each "I do not wish to provide..." checkbox to indicate to a user that their previous selections for that section will be cleared when checked
 
 
-## 1.0.1 – 2023-04-17
-
-### Fixed
-- Fixed a broken link in README.md for creating new issues
-
-
 ## 1.0.0 – 2023-04-14
 
 Initial public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+All notable changes to this project will be documented in this file.
+We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
+
+## 1.0.0 – 2023-04-14
+
+Initial public release.
+
+## 1.0.1 – 2023-04-17
+
+### Fixed
+- Fixed a broken link in README.md for creating new issues
+
+## 1.1.0 - 2024-4-25
+
+### Changed
+- added helper text under each "I do not wish to provide..." checkbox to indicate to a user that their previous selections for that section will be cleared when checked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## 1.0.0 – 2023-04-14
+## 1.1.0 - 2024-4-25
 
-Initial public release.
+### Changed
+- added helper text under each "I do not wish to provide..." checkbox to indicate to a user that their previous selections for that section will be cleared when checked
+
 
 ## 1.0.1 – 2023-04-17
 
 ### Fixed
 - Fixed a broken link in README.md for creating new issues
 
-## 1.1.0 - 2024-4-25
 
-### Changed
-- added helper text under each "I do not wish to provide..." checkbox to indicate to a user that their previous selections for that section will be cleared when checked
+## 1.0.0 – 2023-04-14
+
+Initial public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - added helper text under each "I do not wish to provide..." checkbox to indicate to a user that their previous selections for that section will be cleared when checked
+- typing into an "Other" free form text box now clears the "I do not wish to provide..." checkbox for that section, if typed in after the checkbox was clicked
 
 
 ## 1.0.0 – 2023-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - added helper text under each "I do not wish to provide..." checkbox to indicate to a user that their previous selections for that section will be cleared when checked
-- typing into a free form text box now clears the "I do not wish to provide..." checkbox for that section, if typed in after the checkbox was clicked
+- typing into a free form text box clears the "I do not wish to provide..." checkbox for that section, if typed in after the checkbox was clicked
 
 
 ## 1.0.0 – 2023-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - added helper text under each "I do not wish to provide..." checkbox to indicate to a user that their previous selections for that section will be cleared when checked
-- typing into an "Other" free form text box now clears the "I do not wish to provide..." checkbox for that section, if typed in after the checkbox was clicked
+- typing into a free form text box now clears the "I do not wish to provide..." checkbox for that section, if typed in after the checkbox was clicked
 
 
 ## 1.0.0 – 2023-04-14

--- a/index.html
+++ b/index.html
@@ -912,10 +912,10 @@
         });
       });
 
-      // Clear sibling "I decline..." fields with other fields are checked
+      // Clear sibling "I decline..." fields with other fields are checked or text inputted
       nonDeclineEls.forEach(function (input) {
-        input.addEventListener("change", (event) => {
-          if (event.target && event.target.value && event.target.checked) {
+        input.addEventListener("input", (event) => {
+          if (event.target && event.target.value && event.target.value !== "") {
             clearSiblingDeclineInputs(event.target);
           }
         });

--- a/index.html
+++ b/index.html
@@ -128,13 +128,19 @@
             </div>
             <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
             <div class="usa-checkbox">
-              <input class="usa-checkbox__input decline" id="business-owner-none" type="checkbox" name="business-owner-none" value="business-owner-none" />
-              <label class="usa-checkbox__label" for="business-owner-none"><strong>None of these apply</strong></label>
+              <input class="usa-checkbox__input decline" id="business-owner-none" type="checkbox" name="business-owner-none" value="business-owner-none" aria-describedby="business-owner-none-hint" />
+              <label class="usa-checkbox__label" for="business-owner-none">
+                <strong>None of these apply</strong>
+                <div class="usa-hint" id="business-owner-none-hint">Selecting this option will clear any previous selections for this question</div>
+              </label>
             </div>
             <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
             <div class="usa-checkbox">
-              <input class="usa-checkbox__input decline" id="business-owner-decline" type="checkbox" name="business-owner-decline" value="business-owner-decline" />
-              <label class="usa-checkbox__label" for="business-owner-decline"><strong>I do not wish to provide this information</strong></label>
+              <input class="usa-checkbox__input decline" id="business-owner-decline" type="checkbox" name="business-owner-decline" value="business-owner-decline" aria-describedby="business-owner-decline-hint" />
+              <label class="usa-checkbox__label" for="business-owner-decline">
+                <strong>I do not wish to provide this information</strong>
+                <div class="usa-hint" id="business-owner-decline-hint">Selecting this option will clear any previous selections for this question</div>
+              </label>
             </div>
           </fieldset>
 
@@ -197,8 +203,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-1-ethnicity-decline" type="checkbox" name="principal-owner-1-ethnicity-decline" value="principal-owner-1-ethnicity-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-1-ethnicity-decline"><strong>I do not wish to provide my ethnicity</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-1-ethnicity-decline" type="checkbox" name="principal-owner-1-ethnicity-decline" value="principal-owner-1-ethnicity-decline" aria-describedby="principal-owner-1-ethnicity-decline-hint" />
+                        <label class="usa-checkbox__label" for="principal-owner-1-ethnicity-decline">
+                          <strong>I do not wish to provide my ethnicity</strong>
+                          <div class="usa-hint" id="principal-owner-1-ethnicity-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
 
@@ -210,8 +219,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-1-sex-decline" type="checkbox" name="principal-owner-1-sex-decline" value="principal-owner-1-sex-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-1-sex-decline"><strong>I do not wish to provide my sex/gender</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-1-sex-decline" type="checkbox" name="principal-owner-1-sex-decline" value="principal-owner-1-sex-decline" aria-describedby="principal-owner-1-sex-decline-hint" />
+                        <label class="usa-checkbox__label" for="principal-owner-1-sex-decline">
+                          <strong>I do not wish to provide my sex/gender</strong>
+                          <div class="usa-hint" id="principal-owner-1-sex-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
 
@@ -321,8 +333,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-1-race-decline" type="checkbox" name="principal-owner-1-race-decline" value="principal-owner-1-race-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-1-race-decline"><strong>I do not wish to provide my race</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-1-race-decline" type="checkbox" name="principal-owner-1-race-decline" value="principal-owner-1-race-decline" aria-labelledby="principal-owner-1-race-decline-hint"/>
+                        <label class="usa-checkbox__label" for="principal-owner-1-race-decline">
+                          <strong>I do not wish to provide my race</strong>
+                          <div class="usa-hint" id="principal-owner-1-race-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
                   </div>
@@ -365,8 +380,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-2-ethnicity-decline" type="checkbox" name="principal-owner-2-ethnicity-decline" value="principal-owner-2-ethnicity-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-2-ethnicity-decline"><strong>I do not wish to provide my ethnicity</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-2-ethnicity-decline" type="checkbox" name="principal-owner-2-ethnicity-decline" value="principal-owner-2-ethnicity-decline" aria-labelledby="principal-owner-2-ethnicity-decline-hint" />
+                        <label class="usa-checkbox__label" for="principal-owner-2-ethnicity-decline">
+                          <strong>I do not wish to provide my ethnicity</strong>
+                          <div class="usa-hint" id="principal-owner-2-ethnicity-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
 
@@ -378,8 +396,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-2-sex-decline" type="checkbox" name="principal-owner-2-sex-decline" value="principal-owner-2-sex-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-2-sex-decline"><strong>I do not wish to provide my sex/gender</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-2-sex-decline" type="checkbox" name="principal-owner-2-sex-decline" value="principal-owner-2-sex-decline" aria-describedby="principal-owner-2-sex-decline-hint"/>
+                        <label class="usa-checkbox__label" for="principal-owner-2-sex-decline">
+                          <strong>I do not wish to provide my sex/gender</strong>
+                          <div class="usa-hint" id="principal-owner-2-sex-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
 
@@ -489,8 +510,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-2-race-decline" type="checkbox" name="principal-owner-2-race-decline" value="principal-owner-2-race-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-2-race-decline"><strong>I do not wish to provide my race</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-2-race-decline" type="checkbox" name="principal-owner-2-race-decline" value="principal-owner-2-race-decline" aria-describedby="principal-owner-2-race-decline-hint"/>
+                        <label class="usa-checkbox__label" for="principal-owner-2-race-decline">
+                          <strong>I do not wish to provide my race</strong>
+                          <div class="usa-hint" id="principal-owner-2-race-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
                   </div>
@@ -533,8 +557,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-3-ethnicity-decline" type="checkbox" name="principal-owner-3-ethnicity-decline" value="principal-owner-3-ethnicity-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-3-ethnicity-decline"><strong>I do not wish to provide my ethnicity</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-3-ethnicity-decline" type="checkbox" name="principal-owner-3-ethnicity-decline" value="principal-owner-3-ethnicity-decline" aria-describedby="principal-owner-3-ethnicity-decline-hint" />
+                        <label class="usa-checkbox__label" for="principal-owner-3-ethnicity-decline">
+                          <strong>I do not wish to provide my ethnicity</strong>
+                          <div class="usa-hint" id="principal-owner-3-ethnicity-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
 
@@ -547,7 +574,10 @@
 
                       <div class="usa-checkbox">
                         <input class="usa-checkbox__input decline" id="principal-owner-3-sex-decline" type="checkbox" name="principal-owner-3-sex-decline" value="principal-owner-3-sex-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-3-sex-decline"><strong>I do not wish to provide my sex/gender</strong></label>
+                        <label class="usa-checkbox__label" for="principal-owner-3-sex-decline">
+                          <strong>I do not wish to provide my sex/gender</strong>
+                          <div class="usa-hint" id="business-owner-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
 
@@ -657,8 +687,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-3-race-decline" type="checkbox" name="principal-owner-3-race-decline" value="principal-owner-3-race-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-3-race-decline"><strong>I do not wish to provide my race</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-3-race-decline" type="checkbox" name="principal-owner-3-race-decline" value="principal-owner-3-race-decline" aria-labelledby="principal-owner-3-race-decline-hint"/>
+                        <label class="usa-checkbox__label" for="principal-owner-3-race-decline">
+                          <strong>I do not wish to provide my race</strong>
+                          <div class="usa-hint" id="principal-owner-3-race-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
                   </div>
@@ -701,8 +734,11 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-4-ethnicity-decline" type="checkbox" name="principal-owner-4-ethnicity-decline" value="principal-owner-4-ethnicity-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-4-ethnicity-decline"><strong>I do not wish to provide my ethnicity</strong></label>
+                        <input class="usa-checkbox__input decline" id="principal-owner-4-ethnicity-decline" type="checkbox" name="principal-owner-4-ethnicity-decline" value="principal-owner-4-ethnicity-decline" aria-labelledby="principal-owner-4-ethnicity-decline-hint"/>
+                        <label class="usa-checkbox__label" for="principal-owner-4-ethnicity-decline">
+                          <strong>I do not wish to provide my ethnicity</strong>
+                          <div class="usa-hint" id="principal-owner-4-ethnicity-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
 
@@ -715,7 +751,10 @@
 
                       <div class="usa-checkbox">
                         <input class="usa-checkbox__input decline" id="principal-owner-4-sex-decline" type="checkbox" name="principal-owner-4-sex-decline" value="principal-owner-4-sex-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-4-sex-decline"><strong>I do not wish to provide my sex/gender</strong></label>
+                        <label class="usa-checkbox__label" for="principal-owner-4-sex-decline">
+                          <strong>I do not wish to provide my sex/gender</strong>
+                          <div class="usa-hint" id="business-owner-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
 
@@ -826,7 +865,10 @@
 
                       <div class="usa-checkbox">
                         <input class="usa-checkbox__input decline" id="principal-owner-4-race-decline" type="checkbox" name="principal-owner-4-race-decline" value="principal-owner-4-race-decline" />
-                        <label class="usa-checkbox__label" for="principal-owner-4-race-decline"><strong>I do not wish to provide my race</strong></label>
+                        <label class="usa-checkbox__label" for="principal-owner-4-race-decline">
+                          <strong>I do not wish to provide my race</strong>
+                          <div class="usa-hint" id="business-owner-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                        </label>
                       </div>
                     </fieldset>
                   </div>

--- a/index.html
+++ b/index.html
@@ -912,7 +912,7 @@
         });
       });
 
-      // Clear sibling "I decline..." fields with other fields are checked or text inputted
+      // Clear sibling "I decline..." fields when other fields are checked or text inputted
       nonDeclineEls.forEach(function (input) {
         input.addEventListener("input", (event) => {
           if (event.target && event.target.value && event.target.value !== "") {

--- a/index.html
+++ b/index.html
@@ -573,10 +573,10 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-3-sex-decline" type="checkbox" name="principal-owner-3-sex-decline" value="principal-owner-3-sex-decline" />
+                        <input class="usa-checkbox__input decline" id="principal-owner-3-sex-decline" type="checkbox" name="principal-owner-3-sex-decline" value="principal-owner-3-sex-decline" aria-describedby="principal-owner-3-sex-decline-hint"/>
                         <label class="usa-checkbox__label" for="principal-owner-3-sex-decline">
                           <strong>I do not wish to provide my sex/gender</strong>
-                          <div class="usa-hint" id="business-owner-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                          <div class="usa-hint" id="principal-owner-3-sex-decline-hint">Selecting this option will clear any previous selections for this question</div>
                         </label>
                       </div>
                     </fieldset>
@@ -734,7 +734,7 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-4-ethnicity-decline" type="checkbox" name="principal-owner-4-ethnicity-decline" value="principal-owner-4-ethnicity-decline" aria-labelledby="principal-owner-4-ethnicity-decline-hint"/>
+                        <input class="usa-checkbox__input decline" id="principal-owner-4-ethnicity-decline" type="checkbox" name="principal-owner-4-ethnicity-decline" value="principal-owner-4-ethnicity-decline" aria-labelledby="principal-owner-4-ethnicity-decline-hint" />
                         <label class="usa-checkbox__label" for="principal-owner-4-ethnicity-decline">
                           <strong>I do not wish to provide my ethnicity</strong>
                           <div class="usa-hint" id="principal-owner-4-ethnicity-decline-hint">Selecting this option will clear any previous selections for this question</div>
@@ -750,10 +750,10 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-4-sex-decline" type="checkbox" name="principal-owner-4-sex-decline" value="principal-owner-4-sex-decline" />
+                        <input class="usa-checkbox__input decline" id="principal-owner-4-sex-decline" type="checkbox" name="principal-owner-4-sex-decline" value="principal-owner-4-sex-decline" aria-labelledby="principal-owner-4-sex-decline-hint" />
                         <label class="usa-checkbox__label" for="principal-owner-4-sex-decline">
                           <strong>I do not wish to provide my sex/gender</strong>
-                          <div class="usa-hint" id="business-owner-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                          <div class="usa-hint" id="principal-owner-4-sex-decline-hint">Selecting this option will clear any previous selections for this question</div>
                         </label>
                       </div>
                     </fieldset>
@@ -864,10 +864,10 @@
                       <p class="margin-y-1"><i>&mdash; or &mdash;</i></p>
 
                       <div class="usa-checkbox">
-                        <input class="usa-checkbox__input decline" id="principal-owner-4-race-decline" type="checkbox" name="principal-owner-4-race-decline" value="principal-owner-4-race-decline" />
+                        <input class="usa-checkbox__input decline" id="principal-owner-4-race-decline" type="checkbox" name="principal-owner-4-race-decline" value="principal-owner-4-race-decline" aria-labelledby="principal-owner-4-race-decline-hint" />
                         <label class="usa-checkbox__label" for="principal-owner-4-race-decline">
                           <strong>I do not wish to provide my race</strong>
-                          <div class="usa-hint" id="business-owner-decline-hint">Selecting this option will clear any previous selections for this question</div>
+                          <div class="usa-hint" id="principal-owner-4-race-decline-hint">Selecting this option will clear any previous selections for this question</div>
                         </label>
                       </div>
                     </fieldset>


### PR DESCRIPTION
There have been a few questions coming into SBL Help about if it's the correct behavior that when a user clicks the "I do not wish to provide this information" checkboxes that if it should really clear the other options from that section.

After a lengthy discussion with stakeholders from last year, it was decided to add some helper text underneath these "I do not wish to provide this information" checkboxes to clarify this behavior to both users and developers implementing this form. We got the go ahead to make these changes recently, so here they are.

Another request that came in recently from stakeholders was that typing into any of the "Other" free form text boxes should remove the checkmark from "I do not wish to provide..." for that section, which has been changed.

I've also added a CHANGELOG.md with text approved by legal.

Closes: https://github.com/cfpb/sbl-project/issues/44

## Current behavior:
- As a user, it may be unclear what will happen when I click the option: "I do not wish to provide this information" on a given section

## Changes
- Adds accessible helper text underneath all of the "I do not wish to provide this information" options
- Typing into a free form text box now clears the "I do not wish to provide..." checkbox
- Added a CHANGELOG.md 

## Screenshots

### Helper text underneath "I do not wish to provide this information" options
![Screenshot 2024-04-12 at 8 05 12 AM](https://github.com/cfpb/sbl-sample-form/assets/19983248/714120ce-52d0-4f10-b085-49df1128fa8e)

### Typing into a free form text box now clears the "I do not wish to provide..." checkbox
![clear-on-input (2) (1)](https://github.com/cfpb/sbl-sample-form/assets/19983248/f319e0e6-263d-4962-a240-08bd39910398)

## TODO
- Get approved text for the change: typing into a free form text box now clears the "I do not wish to provide..." checkbox

